### PR TITLE
Performance: Generate part combinations dynamically, rather than storing them all

### DIFF
--- a/modules/common.ts
+++ b/modules/common.ts
@@ -221,7 +221,7 @@ export const calculateBestSetup = (
 	for (let mask = 1; mask < (1 << numParts); mask++) {
 		let comboCost = 0;
 		let comboBoost = 0;
-		let partNames: TuningPartName[] = [];
+		const partNames: TuningPartName[] = [];
 
 		// generate combination for current mask
 		for (let i = 0; i < numParts; i++) {

--- a/modules/common.ts
+++ b/modules/common.ts
@@ -7,7 +7,6 @@ import {
 	TuningSetup,
 } from '@/@types/calculator';
 import tuningParts from '@/data/tuning-parts.json';
-import combinations from 'combinations';
 
 export const getFullPartByName = (partName: TuningPartName) =>
 	tuningParts[partName];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "2.1.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"combinations": "^1.0.0",
 				"next": "^14.2.15",
 				"react": "^18",
 				"react-dom": "^18",
@@ -19,7 +18,6 @@
 				"@commitlint/cli": "^17.7.1",
 				"@commitlint/config-conventional": "^17.7.0",
 				"@react-docgen/cli": "^1.0.4",
-				"@types/combinations": "^1.0.2",
 				"@types/node": "^20",
 				"@types/react": "^18",
 				"@types/react-dom": "^18",
@@ -1286,12 +1284,6 @@
 				"@babel/types": "^7.20.7"
 			}
 		},
-		"node_modules/@types/combinations": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/combinations/-/combinations-1.0.2.tgz",
-			"integrity": "sha512-gxlk08XORUpWGiDJLmMLmP0LvWPoczbDkIQ6LfjTZcgXQFH5u9VrcWYQ/beyG+QtNGI9W4RKAXYiDpAwPWhFcw==",
-			"dev": true
-		},
 		"node_modules/@types/doctrine": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.6.tgz",
@@ -2336,11 +2328,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
-		},
-		"node_modules/combinations": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/combinations/-/combinations-1.0.0.tgz",
-			"integrity": "sha512-aVgTfI/dewHblSn4gF+NZHvS7wtwg9YAPF2EknHMdH+xLsXLLIMpmHkSj64Zxs/R2m9VAAgn3bENjssrn7V4vQ=="
 		},
 		"node_modules/commander": {
 			"version": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 		"push-tags": "git push --tags"
 	},
 	"dependencies": {
-		"combinations": "^1.0.0",
 		"next": "^14.2.15",
 		"react": "^18",
 		"react-dom": "^18",
@@ -31,7 +30,6 @@
 		"@commitlint/cli": "^17.7.1",
 		"@commitlint/config-conventional": "^17.7.0",
 		"@react-docgen/cli": "^1.0.4",
-		"@types/combinations": "^1.0.2",
 		"@types/node": "^20",
 		"@types/react": "^18",
 		"@types/react-dom": "^18",


### PR DESCRIPTION
The current implementation uses the [combinations](https://www.npmjs.com/package/combinations) library to generate all possible combinations of parts at once, storing them in a 2D array. This works well enough for the engines currently implemented, as they do not have enough tunable parts for this to cause any problems. However, some of the DLC engines, such as the _V8 M177 Twin-Turbo AWD (DBX)_ from the Aston Martin DLC, have considerably more tunable parts. The M177, for example, has 24 tunable parts, compared with e.g. the _V8 OHV SS_, which has 18 -- a 2^6 = 64× increase in the number of part combinations. For this engine, the current implementation will quickly consume several gigabytes of memory and freeze until the browser kills it, meaning it never finds a good combination for this engine.

This PR replaces the current implementation with a dynamic version with a ~constant memory footprint. Rather than generating and storing a list of all combinations, only one combination is generated at a time and only the best combination is ever stored. This is achieved with a bitmask method; we iterate from 1 (0 is pointless) to 2^N, where N is the number of parts, and each bit in this value corresponds to whether or not a part is included in the combination. 

This method drastically reduces the memory footprint of the auto-generator, allowing it to be used without crashing for engines with more parts, such as the _V8 M177 Twin-Turbo AWD (DBX)_. It also has a small, but noticeable, improvement on the performance for the existing engines. The use of this method also eliminates the need for the combinations library, and so this has also been removed in this PR.