### PR TITLE
Add missing distributor cap for Rotary 12A

### DIFF
--- a/data/engines.json
+++ b/data/engines.json
@@ -3290,6 +3290,11 @@
 				"cost": 69
 			},
 			{
+				"name": "Ignition Distributor (ROT 12A)",
+				"quantity": 1,
+				"cost": 20
+			},
+			{
 				"name": "Ignition Distributor Rotor",
 				"quantity": 1,
 				"cost": 20

--- a/data/engines.json
+++ b/data/engines.json
@@ -3290,7 +3290,7 @@
 				"cost": 69
 			},
 			{
-				"name": "Ignition Distributor (ROT 12A)",
+				"name": "Ignition Distributor Cap (ROT 12A)",
 				"quantity": 1,
 				"cost": 20
 			},

--- a/data/tuning-parts.json
+++ b/data/tuning-parts.json
@@ -2471,8 +2471,8 @@
 		"version": "1.0.16",
 		"dlc": ""
 	},
-	"Ignition Distributor (ROT 12A)": {
-		"name": "Ignition Distributor (ROT 12A)",
+	"Ignition Distributor Cap (ROT 12A)": {
+		"name": "Ignition Distributor Cap (ROT 12A)",
 		"cost": 175,
 		"boost": 1.5,
 		"costToBoost": 116.67,


### PR DESCRIPTION
Part already exists in `tuning-parts.json` (though under the name "Ignition Distributor (ROT 12A)", instead of "Ignition Distributor Cap (ROT 12A)", it just wasn't listed in the engine configuration.