### PR TITLE
Fix typo in Engine Head (I4 SOHC) part price

### DIFF
--- a/data/tuning-parts.json
+++ b/data/tuning-parts.json
@@ -921,7 +921,7 @@
 	},
 	"Engine Head (I4 SOHC)": {
 		"name": "Engine Head (I4 SOHC)",
-		"cost": 1,
+		"cost": 1000,
 		"boost": 5,
 		"costToBoost": 200,
 		"version": "1.0.0",


### PR DESCRIPTION
Engine Head (I4 SOHC) is listed as having a part price of 1CR instead of 1000CR.